### PR TITLE
Enhancements to file picker UI

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -131,6 +131,10 @@ html.provider-inline header {
   display: none;
 }
 
+body.folderOnly .helper {
+  padding-right: 85px;
+}
+
 .image-library {
   display: flex;
   justify-content: flex-start;
@@ -407,6 +411,11 @@ html.provider-inline header {
   margin-right: 0;
 }
 
+body.folderOnly .drop-note {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .what-to-add-selector {
   position: relative;
 }
@@ -417,26 +426,36 @@ html.provider-inline header {
 }
 
 .drop-note {
-  text-align: center;
+  text-align: right;
   font-size: 12px;
   line-height: 1.8;
+  padding-right: 15px;
 }
 
 .drop-note span {
   display: inline-block;
-  background-color: #E3E9EB;
-  padding: 0 6px;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  color: #b3b3b3;
 }
 
-.add-btn {
+.see-files-holder {
+  position: absolute;
+  bottom: 0;
+  left: 15px;
+  font-size: 12px;
+  line-height: 1.8;
+}
+
+.add-btn,
+.add-folder-btn {
   position: absolute;
   top: 0;
-  right: 15px;
+  right: 0;
 }
 
-.add-btn button {
+.add-btn button,
+.add-btn button:active:focus,
+.add-folder-btn,
+.add-folder-btn:active:focus {
   outline: none;
 }
 

--- a/css/interface.css
+++ b/css/interface.css
@@ -18,10 +18,6 @@ html.provider-inline body {
   overflow: auto;
 }
 
-body.folder-only #app {
-  padding-bottom: 66px;
-}
-
 html.provider-inline #app {
   height: auto;
   max-height: none;
@@ -29,21 +25,6 @@ html.provider-inline #app {
 
 html.provider-inline header {
   display: none;
-}
-
-.see-files-holder {
-  border-top: 1px solid #e3e9eb;
-  padding-top: 10px;
-}
-
-.see-files-nofiles-holder,
-body.folder-only .nofiles-holder {
-  display: none;
-}
-
-body.folder-only .see-files-nofiles-holder,
-.nofiles-holder {
-  display: block;
 }
 
 .spinner-holder {

--- a/css/interface.css
+++ b/css/interface.css
@@ -124,7 +124,7 @@ html.provider-inline header {
 
 .helper {
   line-height: 44px;
-  padding-right: 10px;
+  padding-right: 55px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/css/interface.css
+++ b/css/interface.css
@@ -19,7 +19,7 @@ html.provider-inline body {
 }
 
 body.folder-only #app {
-  padding-bottom: 46px;
+  padding-bottom: 66px;
 }
 
 html.provider-inline #app {
@@ -33,17 +33,17 @@ html.provider-inline header {
 
 .folder-only-info {
   display: none;
-  height: 40px;
+  height: 60px;
   width: 100%;
-  line-height: 40px;
   position: fixed;
   bottom: 6px;
   border-top: 1px solid #e3e9eb;
   background-color: rgba(255,255,255,0.4);
+  align-items: center;
 }
 
 body.folder-only .folder-only-info {
-  display: block;
+  display: flex;
 }
 
 .spinner-holder {

--- a/css/interface.css
+++ b/css/interface.css
@@ -18,6 +18,10 @@ html.provider-inline body {
   overflow: auto;
 }
 
+body.folder-only #app {
+  padding-bottom: 46px;
+}
+
 html.provider-inline #app {
   height: auto;
   max-height: none;
@@ -25,6 +29,21 @@ html.provider-inline #app {
 
 html.provider-inline header {
   display: none;
+}
+
+.folder-only-info {
+  display: none;
+  height: 40px;
+  width: 100%;
+  line-height: 40px;
+  position: fixed;
+  bottom: 6px;
+  border-top: 1px solid #e3e9eb;
+  background-color: rgba(255,255,255,0.4);
+}
+
+body.folder-only .folder-only-info {
+  display: block;
 }
 
 .spinner-holder {

--- a/css/interface.css
+++ b/css/interface.css
@@ -31,19 +31,19 @@ html.provider-inline header {
   display: none;
 }
 
-.folder-only-info {
-  display: none;
-  height: 60px;
-  width: 100%;
-  position: fixed;
-  bottom: 6px;
+.see-files-holder {
   border-top: 1px solid #e3e9eb;
-  background-color: rgba(255,255,255,0.4);
-  align-items: center;
+  padding-top: 10px;
 }
 
-body.folder-only .folder-only-info {
-  display: flex;
+.see-files-nofiles-holder,
+body.folder-only .nofiles-holder {
+  display: none;
+}
+
+body.folder-only .see-files-nofiles-holder,
+.nofiles-holder {
+  display: block;
 }
 
 .spinner-holder {

--- a/interface.html
+++ b/interface.html
@@ -5,8 +5,6 @@
       <a id="help_tip" href="#">Need help?</a>
     </header>
 
-    <div class="folder-only-info text-center text-warning"><small>Please note that file preview is disabled in this view and you'll only be able to select a folder</small></div>
-
     <div class="form-group clearfix">
       <div class="col-sm-4 control-label">
         <label id="browser-label" data-content></label>
@@ -70,6 +68,9 @@
 
   <div class="holder container-fluid">
     <div class="image-library">
+    </div>
+    <div class="see-files-holder text-center">
+      <a href="#" class="browse-files">See files</a>
     </div>
     <div class="spinner-holder hidden">
       <div class="spinner-overlay">Loading...</div>

--- a/interface.html
+++ b/interface.html
@@ -28,7 +28,7 @@
             </div>
           </div>
           <div class="col-sm-2 col-sm-offset-7 col-static">
-            <div class="btn btn-link add-folder-btn"><i class="fa fa-plus-circle fa-fw"></i> folder</div>
+            <div class="btn btn-link add-folder-btn"><i class="fa fa-plus-circle fa-fw"></i> Folder</div>
           </div>
           <div id="progress-bar-wrapper">
             <div id="uploading-wrapper">

--- a/interface.html
+++ b/interface.html
@@ -5,6 +5,8 @@
       <a id="help_tip" href="#">Need help?</a>
     </header>
 
+    <div class="folder-only-info text-center text-warning">File preview is disabled. You need to select a folder.</div>
+
     <div class="form-group clearfix">
       <div class="col-sm-4 control-label">
         <label id="browser-label" data-content></label>

--- a/interface.html
+++ b/interface.html
@@ -28,15 +28,7 @@
             </div>
           </div>
           <div class="col-sm-2 col-sm-offset-7 col-static">
-            <div class="dropdown add-btn">
-              <button class="btn btn-link dropdown-toggle" type="button" id="add-drop-down-menu">
-                Add <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-right" id="add-menu">
-                <li class="add-option" id="actionNewFolder"><a href="#">New folder</a></li>
-                <li class="add-option" id="actionUploadFile"><a href="#">Upload file</a></li>
-              </ul>
-            </div>
+            <div class="btn btn-link add-folder-btn"><i class="fa fa-plus-circle fa-fw"></i> folder</div>
           </div>
           <div id="progress-bar-wrapper">
             <div id="uploading-wrapper">
@@ -61,16 +53,16 @@
         </div>
       </div>
       <div class="drop-note">
-        <span>Drop files here to upload</span>
+        <span>Drop files here to upload or <a href="#" class="actionUploadFile">select files</a></span>
+      </div>
+      <div class="see-files-holder">
+        <a href="#" class="browse-files">See all files</a>
       </div>
     </div>
   </div>
 
   <div class="holder container-fluid">
     <div class="image-library">
-    </div>
-    <div class="see-files-holder text-center">
-      <a href="#" class="browse-files">See files</a>
     </div>
     <div class="spinner-holder hidden">
       <div class="spinner-overlay">Loading...</div>

--- a/interface.html
+++ b/interface.html
@@ -5,7 +5,7 @@
       <a id="help_tip" href="#">Need help?</a>
     </header>
 
-    <div class="folder-only-info text-center text-warning">File preview is disabled. You need to select a folder.</div>
+    <div class="folder-only-info text-center text-warning"><small>Please note that file preview is disabled in this view and you'll only be able to select a folder</small></div>
 
     <div class="form-group clearfix">
       <div class="col-sm-4 control-label">

--- a/js/interface.js
+++ b/js/interface.js
@@ -214,16 +214,19 @@ function getFileTemplate(file) {
 function addFile(file) {
   file.fullname = file.url.substring(file.url.lastIndexOf('/') + 1);
   $imagesContainer.append(getFileTemplate(file));
+  $('.see-files-holder').removeClass('hidden');
   Fliplet.Widget.autosize();
 }
 
 function addFolder(folder) {
   $imagesContainer.append(templates.folder(folder));
+  $('.see-files-holder').removeClass('hidden');
   Fliplet.Widget.autosize();
 }
 
 function noFiles() {
   $imagesContainer.html(templates.nofiles());
+  $('.see-files-holder').addClass('hidden');
   Fliplet.Widget.autosize();
 }
 
@@ -270,6 +273,27 @@ $(document)
       });
     }
   })
+  .on('click', '.browse-files', function(e) {
+    e.preventDefault();
+    var navStack = {}
+    navStack.upTo = cleanNavStack();
+    
+    Fliplet.Studio.emit('overlay', {
+      name: 'widget',
+      options: {
+        size: 'large',
+        package: 'com.fliplet.file-manager',
+        title: 'File Manager',
+        classes: 'data-source-overlay',
+        data: {
+          context: 'overlay',
+          appId: Fliplet.Env.get('appId'),
+          folder: navStack.upTo[navStack.upTo.length - 1],
+          navStack: navStack
+        }
+      }
+    });
+  });
 
 function sortByName(item1, item2) {
   return byLowerCaseName(item1) > byLowerCaseName(item2);
@@ -789,16 +813,21 @@ function init() {
   Fliplet.Widget.autosize();
 }
 
+function cleanNavStack() {
+  var newUpTo = upTo.slice();
+  newUpTo.forEach(function(obj, idx) {
+    newUpTo[idx] = _.omit(obj, ['back']);
+  });
+
+  return newUpTo;
+}
+
 
 Fliplet.Widget.onSaveRequest(function() {
   var data = getSelectedData();
   var navStack = {};
 
-  upTo.forEach(function(obj, idx) {
-    upTo[idx] = _.omit(obj, ['back']);
-  });
-  
-  navStack.upTo = upTo;
+  navStack.upTo = cleanNavStack();
   data.push(navStack);
 
   Fliplet.Widget.save(data).then(function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -27,7 +27,6 @@ if (!(data.selectMultiple && data.selectFiles.length > 1) && !data.selectFiles) 
 
 if (data.type === 'folder') {
   $('#actionUploadFile').remove();
-  $('body').addClass('folder-only');
 }
 
 var selectAvailable = typeof data.selectAvailable !== 'undefined' ? data.selectAvailable : true; // Option to disable the selection of files and folders
@@ -214,19 +213,16 @@ function getFileTemplate(file) {
 function addFile(file) {
   file.fullname = file.url.substring(file.url.lastIndexOf('/') + 1);
   $imagesContainer.append(getFileTemplate(file));
-  $('.see-files-holder').removeClass('hidden');
   Fliplet.Widget.autosize();
 }
 
 function addFolder(folder) {
   $imagesContainer.append(templates.folder(folder));
-  $('.see-files-holder').removeClass('hidden');
   Fliplet.Widget.autosize();
 }
 
 function noFiles() {
   $imagesContainer.html(templates.nofiles());
-  $('.see-files-holder').addClass('hidden');
   Fliplet.Widget.autosize();
 }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -272,7 +272,9 @@ $(document)
   .on('click', '.browse-files', function(e) {
     e.preventDefault();
     var navStack = {}
+    navStack.tempStack = cleanNavStack();
     navStack.upTo = cleanNavStack();
+    navStack.upTo.pop(); // Remove last one
     
     Fliplet.Studio.emit('overlay', {
       name: 'widget',
@@ -284,7 +286,7 @@ $(document)
         data: {
           context: 'overlay',
           appId: Fliplet.Env.get('appId'),
-          folder: navStack.upTo[navStack.upTo.length - 1],
+          folder: navStack.tempStack[navStack.tempStack.length - 1],
           navStack: navStack
         }
       }

--- a/js/interface.js
+++ b/js/interface.js
@@ -26,7 +26,7 @@ data.selectMultiple = data.selectMultiple || false;
 if (!(data.selectMultiple && data.selectFiles.length > 1) && !data.selectFiles) data.selectFiles = [data.selectFiles[0]];
 
 if (data.type === 'folder') {
-  $('#actionUploadFile').remove();
+  $('body').addClass('folderOnly');
 }
 
 var selectAvailable = typeof data.selectAvailable !== 'undefined' ? data.selectAvailable : true; // Option to disable the selection of files and folders
@@ -238,10 +238,10 @@ $('.image-library')
   .on('dblclick', '.image-holder.folder', onFolderDbClick)
   .on('click', '.organization-media', onOrganizationCheck);
 
-$('#actionNewFolder')
+$('.add-folder-btn')
   .on('click', createFolder);
 
-$('#actionUploadFile')
+$('.actionUploadFile')
   .on('click', uploadFile);
 
 $(document)

--- a/js/interface.js
+++ b/js/interface.js
@@ -27,6 +27,7 @@ if (!(data.selectMultiple && data.selectFiles.length > 1) && !data.selectFiles) 
 
 if (data.type === 'folder') {
   $('#actionUploadFile').remove();
+  $('body').addClass('folder-only');
 }
 
 var selectAvailable = typeof data.selectAvailable !== 'undefined' ? data.selectAvailable : true; // Option to disable the selection of files and folders

--- a/js/interface.js
+++ b/js/interface.js
@@ -785,18 +785,21 @@ function init() {
           return;
         }
         //drop down change handler
-        var data = $fileDropDown.val().split('_');
-        var type = data[0];
-        var id = parseInt(data[1]);
-        switch (type) {
-          case 'app':
-            renderApp(id);
-            break;
-          case 'org':
-            renderOrganization(id);
-            break;
-          default:
-            alert('Wrong select type: ' + type);
+        var dataAttr = $fileDropDown.val().split('_');
+        var type = dataAttr[0];
+        var id = parseInt(dataAttr[1]);
+
+        if (!data.selectFiles.length) {
+          switch (type) {
+            case 'app':
+              renderApp(id);
+              break;
+            case 'org':
+              renderOrganization(id);
+              break;
+            default:
+              alert('Wrong selected type: ' + type);
+          }
         }
       });
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -222,7 +222,7 @@ function addFolder(folder) {
 }
 
 function noFiles() {
-  $imagesContainer.html(templates.nofiles());
+  $imagesContainer.html(templates.nofiles(data));
   Fliplet.Widget.autosize();
 }
 

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -83,7 +83,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.image"] = Handlebars.template(
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.nofiles"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <p><strong>No content found</strong></p>\n      <span>Drop files here or use the <i>[Add <span class=\"caret\"></span>]</i> button</span>\n    </div>\n  </div>\n</div>\n";
+    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <div class=\"nofiles-holder\">\n        <p><strong>No content found</strong></p>\n      </div>\n      <div class=\"see-files-nofiles-holder\">\n        <p><strong><a href=\"#\" class=\"browse-files\">See files</a></strong></p>\n      </div>\n      <span>Drop files here or use the <i>[Add <span class=\"caret\"></span>]</i> button</span>\n    </div>\n  </div>\n</div>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.organization"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -83,7 +83,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.image"] = Handlebars.template(
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.nofiles"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <div class=\"nofiles-holder\">\n        <p><strong>No content found</strong></p>\n      </div>\n      <div class=\"see-files-nofiles-holder\">\n        <p><strong><a href=\"#\" class=\"browse-files\">See files</a></strong></p>\n      </div>\n      <span>Drop files here or use the <i>[Add <span class=\"caret\"></span>]</i> button</span>\n    </div>\n  </div>\n</div>\n";
+    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <p><strong>No content found</strong></p>\n      <span>Drop files here or use the <i>[Add <span class=\"caret\"></span>]</i> button</span>\n    </div>\n  </div>\n</div>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.organization"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -83,7 +83,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.image"] = Handlebars.template(
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.nofiles"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <p><strong>No content found</strong></p>\n      <span>Drop files here or use the <i>[Add <span class=\"caret\"></span>]</i> button</span>\n    </div>\n  </div>\n</div>\n";
+    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <p>\n        <span>&#x1F633</span>\n        <br>\n        <strong>This seems to be empty</strong>\n      </p>\n      <small>Click the <i>See all files</i> link to see possible hidden files in this folder.</small>\n    </div>\n  </div>\n</div>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.organization"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -83,7 +83,11 @@ this["Fliplet"]["Widget"]["Templates"]["templates.image"] = Handlebars.template(
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.nofiles"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <p>\n        <span>&#x1F633</span>\n        <br>\n        <strong>This seems to be empty</strong>\n      </p>\n      <small>Click the <i>See all files</i> link to see possible hidden files in this folder.</small>\n    </div>\n  </div>\n</div>\n";
+    var helper;
+
+  return "<div class=\"nofiles-msg\">\n  <div class=\"drop-zone-container\">\n    <div class=\"dropZ\">\n      <p>\n        <span>&#x1F633</span>\n        <br>\n        <strong>This folder seems to be empty</strong>\n      </p>\n      <small>No "
+    + container.escapeExpression(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"type","hash":{},"data":data}) : helper)))
+    + " is found</small>\n    </div>\n  </div>\n</div>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.organization"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/templates/nofiles.interface.hbs
+++ b/js/templates/nofiles.interface.hbs
@@ -1,8 +1,12 @@
 <div class="nofiles-msg">
   <div class="drop-zone-container">
     <div class="dropZ">
-      <p><strong>No content found</strong></p>
-      <span>Drop files here or use the <i>[Add <span class="caret"></span>]</i> button</span>
+      <p>
+        <span>&#x1F633</span>
+        <br>
+        <strong>This seems to be empty</strong>
+      </p>
+      <small>Click the <i>See all files</i> link to see possible hidden files in this folder.</small>
     </div>
   </div>
 </div>

--- a/js/templates/nofiles.interface.hbs
+++ b/js/templates/nofiles.interface.hbs
@@ -1,7 +1,12 @@
 <div class="nofiles-msg">
   <div class="drop-zone-container">
     <div class="dropZ">
-      <p><strong>No content found</strong></p>
+      <div class="nofiles-holder">
+        <p><strong>No content found</strong></p>
+      </div>
+      <div class="see-files-nofiles-holder">
+        <p><strong><a href="#" class="browse-files">See files</a></strong></p>
+      </div>
       <span>Drop files here or use the <i>[Add <span class="caret"></span>]</i> button</span>
     </div>
   </div>

--- a/js/templates/nofiles.interface.hbs
+++ b/js/templates/nofiles.interface.hbs
@@ -1,12 +1,7 @@
 <div class="nofiles-msg">
   <div class="drop-zone-container">
     <div class="dropZ">
-      <div class="nofiles-holder">
-        <p><strong>No content found</strong></p>
-      </div>
-      <div class="see-files-nofiles-holder">
-        <p><strong><a href="#" class="browse-files">See files</a></strong></p>
-      </div>
+      <p><strong>No content found</strong></p>
       <span>Drop files here or use the <i>[Add <span class="caret"></span>]</i> button</span>
     </div>
   </div>

--- a/js/templates/nofiles.interface.hbs
+++ b/js/templates/nofiles.interface.hbs
@@ -4,9 +4,9 @@
       <p>
         <span>&#x1F633</span>
         <br>
-        <strong>This seems to be empty</strong>
+        <strong>This folder seems to be empty</strong>
       </p>
-      <small>Click the <i>See all files</i> link to see possible hidden files in this folder.</small>
+      <small>No {{type}} is found</small>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Folders only**
<img width="366" alt="screen shot 2018-03-07 at 17 12 35" src="https://user-images.githubusercontent.com/7046481/37106883-c88cb276-222a-11e8-8f94-064d7b64065f.png">

---

**With visible files**
<img width="376" alt="screen shot 2018-03-07 at 17 13 11" src="https://user-images.githubusercontent.com/7046481/37106902-d947bf0c-222a-11e8-9a14-b53587664a06.png">

---

**Empty status - folders**
<img width="365" alt="screen shot 2018-03-07 at 17 11 55" src="https://user-images.githubusercontent.com/7046481/37106829-aaa5b1b8-222a-11e8-877a-fd33bdf810f5.png">

---

**Empty status - files**
<img width="380" alt="screen shot 2018-03-07 at 17 10 41" src="https://user-images.githubusercontent.com/7046481/37106766-8e750ad4-222a-11e8-9768-c7c8a6a82e0c.png">

@tonytlwu @jgustafsson24 Updated UI, now instead of letting users know that they can't see the files, we have a link to open File Manager so they can see them.