### PR TITLE
Save navstack ref to each file

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -827,9 +827,12 @@ function cleanNavStack() {
 Fliplet.Widget.onSaveRequest(function() {
   var data = getSelectedData();
   var navStack = {};
-  
   navStack.upTo = cleanNavStack();
-  data.push(navStack);
+
+  // Saves reference of navstack for use in File Manager
+  data.forEach(function(obj, idx) {
+    obj.navStackRef = navStack
+  });
 
   Fliplet.Widget.save(data).then(function() {
     Fliplet.Widget.complete();


### PR DESCRIPTION
We need to save the navstack reference created by the file picker in order to open the file/folder in the file manager overlay, where applicable.

**BEFORE**
Was saving the navstack reference in the same array that contains the files selected.
E.g.
```
[
  0: { id: 1, ... } // File or folder selected
  1: { upTo: []} // navstack reference
]
```

**AFTER**
Now we save the navstack reference along with the file/folder selected
E.g.
```
[
  0: {id: 1, navStackRef: {}, ...}
]
```