### PR TITLE
Fixed file picker file extension check

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -980,7 +980,7 @@ function uploadFiles(files) {
         handleUploadingWrongFile();
         break;
       }
-    } else{
+    } else if(data.fileExtension.length) {
       var isFileExtensionApproved = data.fileExtension.some(function(ext) {
         return extension === '.' + ext.toLowerCase();
       });
@@ -1059,7 +1059,7 @@ function handleUploadingWrongFile() {
 }
 
 function showWrongFileError() {
-  var supportedExtensions = data.fileExtension && data.fileExtension.length
+  var supportedExtensions = data.fileExtension.length
     ? data.fileExtension.join(', ').toUpperCase()
     : extensionDictionary[data.type].join(', ').toUpperCase();
 


### PR DESCRIPTION
We took into account the `fileExtension` constraints even when they weren't passed which was wrong.
Ref. https://github.com/Fliplet/fliplet-studio/issues/3719