### PR TITLE
Restore deleted folder/file when restoring the selection of a folder/file

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -603,7 +603,7 @@ function restoreWidgetState() {
     url: 'v1/media/' + (isFile ? 'files' : 'folders') + '/' + file.id
   }).then(function (res) {
     if (!res.deletedAt) {
-      return Promise.resolve(res);
+      return res;
     }
 
     return Fliplet.Modal.confirm({
@@ -621,7 +621,7 @@ function restoreWidgetState() {
       }
     }).then(function (restore) {
       if (!restore) {
-        return Promise.resolve(res);
+        return res;
       }
 
       return Fliplet.API.request({
@@ -630,7 +630,7 @@ function restoreWidgetState() {
       }).then(function () {
         // File/folder restored
         delete res.deletedAt;
-        return Promise.resolve(res);
+        return res;
       }).catch(function () {
         // Deletion failed, continue restoring widget state
         // This will restore the widget to its default state


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4503

When restoring the selection of a deleted folder/file, user will be shown the following:

![image](https://user-images.githubusercontent.com/290733/59267031-0ec40100-8c41-11e9-8485-7a1bc7cfaec4.png)
