### PR TITLE
Ensure "Delete" dropdown action isn't clipped in the UI

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -200,7 +200,7 @@ body.folderOnly .helper {
   color: #333;
   outline: none;
 }
-    
+
 .image-overlay {
   position: absolute;
   top: 0;
@@ -300,7 +300,7 @@ body.folderOnly .helper {
 
 .more-options ul.dropdown-menu li {
   display: block;
-  padding: 3px 35px 3px 20px;
+  padding: 3px 25px 3px 20px;
   clear: both;
   font-weight: normal;
   line-height: 1.42857;
@@ -581,4 +581,12 @@ body.folderOnly .drop-note {
   content: "";
   display: block;
   margin-bottom: 110px;
+}
+
+.dropdown-menu {
+  min-width: 115px;
+}
+
+.delete-file {
+  text-align: right;
 }

--- a/css/interface.css
+++ b/css/interface.css
@@ -585,8 +585,5 @@ body.folderOnly .drop-note {
 
 .dropdown-menu {
   min-width: 115px;
-}
-
-.delete-file {
   text-align: right;
 }


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#2441

## Description
Changed dropdown-menu width. Text aligned right.

## Screenshots/screencasts
<img width="381" alt="Demo 2" src="https://user-images.githubusercontent.com/52824207/63022924-a269b600-beac-11e9-993e-10116277d8df.png">
<img width="381" alt="Demo 3" src="https://user-images.githubusercontent.com/52824207/63022925-a269b600-beac-11e9-80cd-3194d8d151bf.png">
<img width="381" alt="Demo 1" src="https://user-images.githubusercontent.com/52824207/63022926-a269b600-beac-11e9-9788-ee58a764736c.png">

## Backward compatibility
This change is fully backward compatible.
