### PR TITLE
Fixed css glitch when hovering over images

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -29,6 +29,11 @@ if (data.type === 'folder') {
   $('body').addClass('folderOnly');
 }
 
+// if file picker called from image component add overflow hidden to remove double scroll bar
+if (data.filePickerOpenFromImage) {
+  $('html').css('overflow-y', 'hidden');
+}
+
 var selectAvailable = typeof data.selectAvailable !== 'undefined' ? data.selectAvailable : true; // Option to disable the selection of files and folders
 var templates = {};
 var upTo = [];


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4481

Should also fix
Fliplet/fliplet-studio#4235
Fliplet/fliplet-studio#2533

## Description
The idea is to remove scroll bar from file-picker only if it is called from the image component. So, when we initiate file-picker from image component we pass extra data which we process. In file-picker, if we receive information that file-picker is called from image component we add an overflow-y hidden property to HTML to hide the second scrollbar.

## Screenshots/screencasts
![Scroll-fix ](https://user-images.githubusercontent.com/52824207/63519679-0bc87500-c4fc-11e9-9447-3b0a7bf1f50c.gif)

## Backward compatibility
This change is fully backward compatible.

## Notes
Works together with PR https://github.com/Fliplet/fliplet-widget-image/pull/42