### PR TITLE
Reload folder when closed file manager 2655

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -926,6 +926,15 @@ function init() {
   Fliplet.Widget.autosize();
 }
 
+// Reload content when closing overlay (file manager)
+Fliplet.Studio.onMessage(function (event) {
+  var data = event.data;
+
+  if (data.event === 'overlay-close' && data.title === 'File Manager') {
+    upTo[upTo.length - 1].back();
+  }
+});
+
 function cleanNavStack() {
   var newUpTo = upTo.slice();
   newUpTo.forEach(function(obj, idx) {


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/2655
## Description
Added functionality to reload file picker folder if upload or create items in file manager.
## Screenshots/screencasts
https://cl.ly/d7e4a7ca3aa5
## Backward compatibility
This change is fully backward compatible.