### PR TITLE
File name is limited to 3 lines

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -256,6 +256,28 @@ body.folderOnly .helper {
   font-size: 11px;
   margin-top: 1px;
   word-break: break-word;
+  overflow: hidden;
+  position: relative;
+  line-height: 1.4em;
+  max-height: 4.2em;
+  padding-right: 8px;
+}
+
+.image-title:before {
+  content: '...';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+}
+
+.image-title:after {
+  content: '';
+  position: absolute;
+  right: 0;
+  width: 1em;
+  height: 1em;
+  margin-top: 0.2em;
+  background: #f8f6f7;
 }
 
 .folder-selection {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#1615

## Description
Limited file name length to 3 lines. If filename is longer then 3 lines, the ellipsis is inserted at the end of the third line.

## Screenshots/screencasts
<img width="378" alt="longfile demo" src="https://user-images.githubusercontent.com/52824207/64324728-8e0e6a00-cfcf-11e9-944c-a86f3e73f075.png">

## Backward compatibility
This change is fully backward compatible.