### PR TITLE
Clicking on "Need help" now leads to Fliplet documentation about Selecting files

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -2,7 +2,7 @@
   <div class="menu-fixed form-horizontal">
     <header>
       <p>File picker</p>
-      <a id="help_tip" href="#">Need help?</a>
+      <a href="https://help.fliplet.com/article/169-selecting-files">Need help?</a>
     </header>
 
     <div class="form-group clearfix">

--- a/js/interface.js
+++ b/js/interface.js
@@ -269,11 +269,6 @@ function noFiles() {
 }
 
 // events
-$('#app')
-  .on('click', '#help_tip', function() {
-    alert("During beta, please use live chat and let us know what you need help with.");
-  });
-
 $('.image-library')
   .on('click', '.image-holder.file', onFileClick)
   .on('click', '.image-holder.folder', onFolderClick)


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4959

Description
Added link on "Need help" button. Removed function that triggered an alert.

Backward compatibility
This change is fully backward compatible.