### PR TITLE
Now uploaded file will be selected automatically

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -18,7 +18,6 @@ var data = Fliplet.Widget.getData() || {};
 
 data.type = data.type || '';
 data.selectFiles = data.selectFiles || [];
-data.autoSelectOnUpload = data.autoSelectOnUpload || false;
 
 if (!Array.isArray(data.selectFiles)) data.selectFiles = [data.selectFiles];
 data.fileExtension = data.fileExtension || [];
@@ -995,6 +994,9 @@ $fileInput.on('click', function(e) {
 $fileInput.on('change', function(e) {
   var files = e.target.files;
   if (!files.length) return;
+  
+  data.autoSelectOnUpload = files.length === 1;
+
   uploadFiles(files);
   clearFileInput();
 });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5237

## Description
If the user uploaded 1 file it will be selected automatically.

## Screenshots/screencasts
![select-file-fix](https://user-images.githubusercontent.com/52824207/69330484-ad767400-0c5b-11ea-90d2-84cf711484a7.gif)

## Backward compatibility
This change is fully backward compatible.