### PR TITLE
User is now able to switch to the organisation folder via the "Browse files in" dropdown.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -22,6 +22,7 @@ data.selectFiles = data.selectFiles || [];
 if (!Array.isArray(data.selectFiles)) data.selectFiles = [data.selectFiles];
 data.fileExtension = data.fileExtension || [];
 data.selectMultiple = data.selectMultiple || false;
+data.allowOrganisationFolder = !(data.allowOrganisationFolder === false);
 if (!(data.selectMultiple && data.selectFiles.length > 1) && !data.selectFiles) data.selectFiles = [data.selectFiles[0]];
 
 if (data.type === 'folder') {
@@ -867,9 +868,11 @@ function init() {
 
       // Organisations
       if (thisOrganisation) {
-        dropDownHtml.push('<optgroup label="--- Organisation ---">');
-        dropDownHtml.push('<option value="org_' + thisOrganisation.id + '">' + thisOrganisation.name + '</option>');
-        dropDownHtml.push('</optgroup>');
+        if (data.allowOrganisationFolder) {
+          dropDownHtml.push('<optgroup label="--- Organisation ---">');
+          dropDownHtml.push('<option value="org_' + thisOrganisation.id + '">' + thisOrganisation.name + '</option>');
+          dropDownHtml.push('</optgroup>');
+        }
         organizations.push({
           id: thisOrganisation.id,
           name: thisOrganisation.name
@@ -994,7 +997,7 @@ $fileInput.on('click', function(e) {
 $fileInput.on('change', function(e) {
   var files = e.target.files;
   if (!files.length) return;
-  
+
   data.autoSelectOnUpload = files.length === 1;
 
   uploadFiles(files);

--- a/js/interface.js
+++ b/js/interface.js
@@ -22,7 +22,7 @@ data.selectFiles = data.selectFiles || [];
 if (!Array.isArray(data.selectFiles)) data.selectFiles = [data.selectFiles];
 data.fileExtension = data.fileExtension || [];
 data.selectMultiple = data.selectMultiple || false;
-data.allowOrganisationFolder = !(data.allowOrganisationFolder === false);
+data.allowOrganisationFolder = data.allowOrganisationFolder !== false;
 if (!(data.selectMultiple && data.selectFiles.length > 1) && !data.selectFiles) data.selectFiles = [data.selectFiles[0]];
 
 if (data.type === 'folder') {

--- a/js/interface.js
+++ b/js/interface.js
@@ -873,6 +873,7 @@ function init() {
           dropDownHtml.push('<option value="org_' + thisOrganisation.id + '">' + thisOrganisation.name + '</option>');
           dropDownHtml.push('</optgroup>');
         }
+
         organizations.push({
           id: thisOrganisation.id,
           name: thisOrganisation.name


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4687

## Description
To make this work Custom fonts layout should be changed to pass to file picker allowOrganisationFolder  = false like this
![image-demo](https://user-images.githubusercontent.com/52824207/71098917-1dc0d880-21bb-11ea-96d8-706cbed99155.PNG)

## Screenshots/screencasts
![file-picker-org-demo](https://user-images.githubusercontent.com/52824207/71098992-3c26d400-21bb-11ea-8bb7-af9af440b15b.gif)

## Backward compatibility
This change is fully backward compatible.