### PR TITLE
File picker cannot be saved with nothing selected

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -18,6 +18,8 @@ var data = Fliplet.Widget.getData() || {};
 data.type = data.type || '';
 data.selectFiles = data.selectFiles || [];
 
+Fliplet.Widget.toggleSaveButton(data.selectFiles.length);
+
 if (!Array.isArray(data.selectFiles)) data.selectFiles = [data.selectFiles];
 data.fileExtension = data.fileExtension || [];
 data.selectMultiple = data.selectMultiple || false;
@@ -517,6 +519,8 @@ function selectFile(id) {
   if (!data.selectMultiple) unselectAll();
   file.selected = isSelected;
 
+  Fliplet.Widget.toggleSaveButton(isSelected);
+
   var $el = $('.item-holder[data-file-id=' + id + ']');
   $el[!!file.selected ? 'addClass' : 'removeClass']('selected');
   emitSelected();
@@ -533,6 +537,8 @@ function selectFolder(id) {
   var isSelected = !folder.selected;
   if (!data.selectMultiple) unselectAll();
   folder.selected = isSelected;
+
+  Fliplet.Widget.toggleSaveButton(isSelected);
 
   var $el = $('.item-holder[data-folder-id=' + id + ']');
   $el[!!folder.selected ? 'addClass' : 'removeClass']('selected');
@@ -959,7 +965,6 @@ function cleanNavStack() {
 
   return newUpTo;
 }
-
 
 Fliplet.Widget.onSaveRequest(function() {
   var data = _.map(getSelectedData(), function(file) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6033

## Description
The issue occurred when trying to save file-picker without anything selected. I suggest that we simply disallow turn off the save button if nothing is selected. I carefully tested it on many components, but Inna has to make sure it does not break anything) 

## Screenshots/screencasts
![file-picker](https://user-images.githubusercontent.com/52824207/78448592-c750aa80-7682-11ea-8849-4326c59f1c14.gif)

## Backward compatibility
This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii 