### PR TITLE
[Fix] It is not possible to delete the selected folder and Save data in file picker

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -307,14 +307,18 @@ $(document)
     });
   })
   .on('click', '.delete-folder', function() {
-    var folderID = $(this).parents('.item-holder').data('folder-id');
     var $elementToDelete = $(this).parents('.item-holder');
+    var folderID = $elementToDelete.data('folder-id');
 
     Fliplet.Modal.confirm({
       message: 'Are you sure you want to delete the folder?'
     }).then(function(result) {
       if (!result) {
         return;
+      }
+
+      if ($elementToDelete.hasClass('selected')) {
+        Fliplet.Widget.toggleSaveButton(false);
       }
 
       Fliplet.Media.Folders.delete(folderID).then(function() {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#6310

## Description
When folder is deleted save button will be deactivated.

## Screencast
https://streamable.com/gpd2tw

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko