### PR TITLE
OD-698 [Fix] Folder name length limit added

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1076,9 +1076,10 @@ function uploadFile() {
   $fileInput.click();
 }
 
-function createFolder() {
+function createFolder(event, folderName) {
   Fliplet.Modal.prompt({
-    title: 'Please enter a folder name'
+    title: 'Please enter a folder name',
+    value: folderName || ''
   }).then(function(result) {
     if (result === null) {
       return;
@@ -1089,7 +1090,7 @@ function createFolder() {
         title: 'Failed to create folder',
         message: 'Folder name must be 45 characters or less'
       }).then(function () {
-        createFolder()
+        createFolder(null, result);
       });
 
       return;

--- a/js/interface.js
+++ b/js/interface.js
@@ -1084,6 +1084,17 @@ function createFolder() {
       return;
     }
 
+    if (result.length > 45) {
+      Fliplet.Modal.alert({ 
+        title: 'Failed to create folder',
+        message: 'Folder name must be 45 characters or less'
+      }).then(function () {
+        createFolder()
+      });
+
+      return;
+    }
+
     var folderName = result.trim() || 'Untitled folder';
     var config = {
       name: folderName


### PR DESCRIPTION
@romanyosyfiv

OD-698 https://weboo.atlassian.net/browse/OD-698

## Description
**Problem:** The user can enter a folder name of any length. The title of a created folder in the File Manager is trimmed to 45 characters even if it is longer
**Solution:** Added name length limit. The user cannot enter a folder name longer than 45 characters

## Screenshots/screencasts
https://storyxpress.co/video/kyk34myusuj3xji14

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko