### PR TITLE
Fix file picker crash on init and upload when no type filter is set

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -18,7 +18,7 @@ var data = Fliplet.Widget.getData() || {};
 var currentAppId;
 
 data.type = data.type || '';
-data.selectFiles = data.selectFiles || [];
+data.selectFiles = (typeof data.selectFiles === 'object' && data.selectFiles) ? data.selectFiles : [];
 
 Fliplet.Widget.toggleSaveButton(data.selectFiles.length);
 
@@ -1288,36 +1288,41 @@ function uploadFiles(files) {
   var confirmedType;
   var confirmedExt;
   var formData = new FormData();
+  var hasTypeFilter = data.type && validType[data.type];
 
   for (var i = 0; i < files.length; i++) {
     var fileName = files[i].name;
     var dotIndex = fileName.lastIndexOf('.');
     var extension = fileName.substring(dotIndex).toLowerCase();
 
-    confirmedType = _.find(validType[data.type].mimetype, function(type) {
-      return type === files[i].type;
-    });
-
-    if (!confirmedType) {
-      confirmedExt = _.find(extensionDictionary[data.type], function(ext) {
-        return '.' + ext === extension;
+    if (!hasTypeFilter) {
+      confirmedType = true;
+    } else {
+      confirmedType = _.find(validType[data.type].mimetype, function(type) {
+        return type === files[i].type;
       });
 
-      if (!confirmedExt) {
-        handleUploadingWrongFile();
-        break;
-      }
-    } else if (data.fileExtension.length) {
-      var isFileExtensionApproved = data.fileExtension.some(function(ext) {
-        return extension === '.' + ext.toLowerCase();
-      });
-      /**
-       * if type was found in our valid types and fileExtension configuration was passed
-       * check if the file is from the correct fileExtension
-       */
-      if (!isFileExtensionApproved) {
-        handleUploadingWrongFile();
-        break;
+      if (!confirmedType) {
+        confirmedExt = _.find(extensionDictionary[data.type], function(ext) {
+          return '.' + ext === extension;
+        });
+
+        if (!confirmedExt) {
+          handleUploadingWrongFile();
+          break;
+        }
+      } else if (data.fileExtension.length) {
+        var isFileExtensionApproved = data.fileExtension.some(function(ext) {
+          return extension === '.' + ext.toLowerCase();
+        });
+        /**
+         * if type was found in our valid types and fileExtension configuration was passed
+         * check if the file is from the correct fileExtension
+         */
+        if (!isFileExtensionApproved) {
+          handleUploadingWrongFile();
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
## What
Fixes two crashes that happen when the file picker is opened with **no `type` filter** (i.e. an "all types" picker).

## Why
When the picker is opened without a `type` (browse/select any file):

1. **Init crash** — if `data.selectFiles` comes through as a boolean (e.g. `true` from provider params), it was treated as a file array, producing a `400` request to `/v1/media/folders/undefined`.
2. **Upload crash** — `data.type` is empty, so `validType[data.type]` is `undefined` and `uploadFiles()` threw `TypeError: Cannot read properties of undefined (reading 'mimetype')`.

## How
- Coerce non-object `selectFiles` to `[]`:
  ```js
  data.selectFiles = (typeof data.selectFiles === 'object' && data.selectFiles) ? data.selectFiles : [];
  ```
- Skip MIME/extension validation in `uploadFiles()` when there's no type filter (`hasTypeFilter = data.type && validType[data.type]`); with no filter, any file is accepted.

Single file changed (`js/interface.js`), +28/-23.

## Scope / not included
Deliberately crash-fix only. It does **not** relax `extensionClickFilter`, so existing files whose extension isn't in the picker's dictionary (e.g. `.zip`, `.csv`, `.json`) still resolve to `'others'` and remain unselectable. Making those selectable is a separate change.

## Note
Needs a widget redeploy after merge to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)